### PR TITLE
Making the library more embed-friendly

### DIFF
--- a/glfw.lua
+++ b/glfw.lua
@@ -969,7 +969,15 @@ mod.cb = cb
 local function init(self, name)
   ffi.cdef(header)
 
-  bind = ffi.load(name)
+  if name then
+    bind = ffi.load(name)
+  else
+    -- If no library argument is provided, we just
+    -- assume that the appropriate GLFW libraries
+    -- are already statically linked to the calling
+    -- program
+    bind = ffi.C
+  end
 
   ffi.metatype('GLFWmonitor', monitor_mt)
   ffi.metatype('GLFWwindow', window_mt)


### PR DESCRIPTION
Allows the import to be done without the `name` parameter, which will simply assume that the GLFW library was linked to the target project. 

E.g.

``` lua
-- For dynamic symbol lookup
local glfw = require 'glfw' ('glfw3')

-- For executables that are already linked against GLFW
local glfw = require 'glfw' ()
```
